### PR TITLE
Remove deprecated functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bin
 src
 libssh-*
 id_rsa*
+
+# Custom
+.vscode

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -70,8 +70,11 @@ static int auth_password(ssh_session session, const char *user,
 
     char *escaped_user = escape((char *) user);
     char *escaped_pass = escape((char *) pass);
-    char *poll_msg = malloc(sizeof(char) * (strlen(escaped_user) + strlen(escaped_pass)) + 8);
+    int string_len = (strlen(escaped_user) + strlen(escaped_pass)) + 11;
+    char *poll_msg = malloc(sizeof(char) * string_len);
+
     sprintf(poll_msg, "[\"%s\",\"%s\",\"%i\"]", escaped_user, escaped_pass, sdata->auth_attempts);
+    write(sdata->queue->chan[1], &string_len, sizeof(int));
     write(sdata->queue->chan[1], poll_msg, sizeof(char[256]));
 
     // Use logic like this to trick bots into thinking they've authenticated.

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -48,15 +48,7 @@ static int auth_password(ssh_session session, const char *user,
 
     (void) session;
 
-    password_auth_attempt_msg msg = {
-        .user = user,
-        .pass = pass,
-        .session = session
-    };
-
-    push_password_msg(sdata->queue, &msg);
-
-    char poll_msg[256];
+    char poll_msg[512];
     sprintf(poll_msg, "[\"%s\",\"%s\"]", user, pass);
     write(sdata->queue->chan[1], poll_msg, sizeof(char[256]));
 
@@ -66,14 +58,12 @@ static int auth_password(ssh_session session, const char *user,
     //     return SSH_AUTH_SUCCESS;
     // }
 
-    printf("%s - %s\n", msg.user, msg.pass);
-
     sdata->auth_attempts++;
 
     return SSH_AUTH_DENIED;
 }
 
-void handle_auth(ssh_session session, password_queue *pqueue) {
+void handle_auth(ssh_session session, auth_queue *pqueue) {
     struct session_data_struct sdata = {
         .channel = NULL,
         .auth_attempts = 0,

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -1,6 +1,24 @@
 #include <stdio.h>
 #include <poll.h>
+#include <ctype.h>
 #include "./honeyshell.h"
+
+char *escape(char *str) {
+    char *escaped = malloc(sizeof(char) * strlen(str) * 2);
+    memset(escaped, 0, strlen(str) * 2);
+
+    for (int i = 0; i < strlen(str); i++) {
+        if (str[i] == '\\') {
+            strcat(escaped, "\\\\");
+        } else if (str[i] == '"') {
+            strcat(escaped, "\\\"");
+        } else {
+            sprintf(escaped, "%s%c", escaped, str[i]);
+        }
+    }
+
+    return escaped;
+}
 
 const char *get_ssh_key_type(const ssh_key key) {
 	if (key == NULL) {
@@ -51,7 +69,7 @@ static int auth_password(ssh_session session, const char *user,
     sdata->auth_attempts++;
 
     char poll_msg[512];
-    sprintf(poll_msg, "[\"%s\",\"%s\",\"%i\"]", user, pass, sdata->auth_attempts);
+    sprintf(poll_msg, "[\"%s\",\"%s\",\"%i\"]", escape((char *) user), escape((char *) pass), sdata->auth_attempts);
     write(sdata->queue->chan[1], poll_msg, sizeof(char[256]));
 
     // Use logic like this to trick bots into thinking they've authenticated.

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -48,8 +48,10 @@ static int auth_password(ssh_session session, const char *user,
 
     (void) session;
 
+    sdata->auth_attempts++;
+
     char poll_msg[512];
-    sprintf(poll_msg, "[\"%s\",\"%s\"]", user, pass);
+    sprintf(poll_msg, "[\"%s\",\"%s\",\"%i\"]", user, pass, sdata->auth_attempts);
     write(sdata->queue->chan[1], poll_msg, sizeof(char[256]));
 
     // Use logic like this to trick bots into thinking they've authenticated.
@@ -57,8 +59,6 @@ static int auth_password(ssh_session session, const char *user,
     //     sdata->authenticated = 1;
     //     return SSH_AUTH_SUCCESS;
     // }
-
-    sdata->auth_attempts++;
 
     return SSH_AUTH_DENIED;
 }

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -58,7 +58,7 @@ static int auth_password(ssh_session session, const char *user,
 
     char poll_msg[256];
     sprintf(poll_msg, "[\"%s\",\"%s\"]", user, pass);
-    write(sdata->queue->chan[1], poll_msg, sizeof(char[256])); // &sdata->auth_attempts, sizeof(int));
+    write(sdata->queue->chan[1], poll_msg, sizeof(char[256]));
 
     // Use logic like this to trick bots into thinking they've authenticated.
     // if (strcmp(user, username) == 0 && strcmp(pass, password) == 0) {

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -68,8 +68,10 @@ static int auth_password(ssh_session session, const char *user,
 
     sdata->auth_attempts++;
 
-    char poll_msg[512];
-    sprintf(poll_msg, "[\"%s\",\"%s\",\"%i\"]", escape((char *) user), escape((char *) pass), sdata->auth_attempts);
+    char *escaped_user = escape((char *) user);
+    char *escaped_pass = escape((char *) pass);
+    char *poll_msg = malloc(sizeof(char) * (strlen(escaped_user) + strlen(escaped_pass)) + 8);
+    sprintf(poll_msg, "[\"%s\",\"%s\",\"%i\"]", escaped_user, escaped_pass, sdata->auth_attempts);
     write(sdata->queue->chan[1], poll_msg, sizeof(char[256]));
 
     // Use logic like this to trick bots into thinking they've authenticated.

--- a/honeyshell.c
+++ b/honeyshell.c
@@ -56,9 +56,9 @@ static int auth_password(ssh_session session, const char *user,
 
     push_password_msg(sdata->queue, &msg);
 
-    // char poll_msg[4];
-    // sprintf(poll_msg, "%i", sdata->auth_attempts);
-    write(sdata->queue->chan[1], &sdata->auth_attempts, sizeof(int));
+    char poll_msg[256];
+    sprintf(poll_msg, "[\"%s\",\"%s\"]", user, pass);
+    write(sdata->queue->chan[1], poll_msg, sizeof(char[256])); // &sdata->auth_attempts, sizeof(int));
 
     // Use logic like this to trick bots into thinking they've authenticated.
     // if (strcmp(user, username) == 0 && strcmp(pass, password) == 0) {

--- a/honeyshell.h
+++ b/honeyshell.h
@@ -1,0 +1,76 @@
+#ifndef HONEYSHELL_H
+#define HONEYSHELL_H
+
+#include <stdlib.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <grp.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <libssh/libssh.h>
+#include <libssh/server.h>
+#include <libssh/callbacks.h>
+
+struct ssh_key_struct {
+    enum ssh_keytypes_e type;
+    int flags;
+    const char *type_c;
+	int ecdsa_nid;
+#if defined(HAVE_LIBGCRYPT)
+    gcry_sexp_t dsa;
+    gcry_sexp_t rsa;
+    gcry_sexp_t ecdsa;
+#elif defined(HAVE_LIBMBEDCRYPTO)
+    mbedtls_pk_context *rsa;
+    mbedtls_ecdsa_context *ecdsa;
+    void *dsa;
+#elif defined(HAVE_LIBCRYPTO)
+    DSA *dsa;
+    RSA *rsa;
+# if defined(HAVE_OPENSSL_ECC)
+    EC_KEY *ecdsa;
+# else
+    void *ecdsa;
+# endif
+#endif
+    void *cert;
+    enum ssh_keytypes_e cert_type;
+};
+
+struct password_auth_attempt_msg_struct {
+    ssh_session session;
+    const char *user;
+    const char *pass;
+};
+typedef struct password_auth_attempt_msg_struct password_auth_attempt_msg;
+
+typedef struct password_queue_node_struct {
+    struct password_queue_node_struct *next_node;
+    password_auth_attempt_msg *msg;
+} password_queue_node;
+
+typedef struct password_queue_struct {
+    password_queue_node *first;
+    password_queue_node *last;
+    int count;
+    int chan[2];
+} password_queue;
+
+struct session_data_struct {
+    ssh_channel channel;
+    int auth_attempts;
+    int authenticated;
+    password_queue *queue;
+};
+
+const char *get_ssh_key_type(const ssh_key key);
+
+void handle_auth(ssh_session session, password_queue *pqueue);
+
+password_queue create_password_queue();
+password_auth_attempt_msg *wait_for_password(password_queue *queue);
+void push_password_msg(password_queue *queue, password_auth_attempt_msg *msg);
+password_auth_attempt_msg *get_password_msg(password_queue *queue);
+int is_password_queue_empty(password_queue *queue);
+
+#endif

--- a/honeyshell.h
+++ b/honeyshell.h
@@ -68,7 +68,7 @@ const char *get_ssh_key_type(const ssh_key key);
 void handle_auth(ssh_session session, password_queue *pqueue);
 
 password_queue create_password_queue();
-password_auth_attempt_msg *wait_for_password(password_queue *queue);
+char *wait_for_password(password_queue *queue);
 void push_password_msg(password_queue *queue, password_auth_attempt_msg *msg);
 password_auth_attempt_msg *get_password_msg(password_queue *queue);
 int is_password_queue_empty(password_queue *queue);

--- a/honeyshell.h
+++ b/honeyshell.h
@@ -44,33 +44,25 @@ struct password_auth_attempt_msg_struct {
 };
 typedef struct password_auth_attempt_msg_struct password_auth_attempt_msg;
 
-typedef struct password_queue_node_struct {
-    struct password_queue_node_struct *next_node;
-    password_auth_attempt_msg *msg;
-} password_queue_node;
-
-typedef struct password_queue_struct {
-    password_queue_node *first;
-    password_queue_node *last;
-    int count;
+typedef struct queue_struct {
     int chan[2];
-} password_queue;
+} auth_queue;
 
 struct session_data_struct {
     ssh_channel channel;
     int auth_attempts;
     int authenticated;
-    password_queue *queue;
+    auth_queue *queue;
 };
 
 const char *get_ssh_key_type(const ssh_key key);
 
-void handle_auth(ssh_session session, password_queue *pqueue);
+void handle_auth(ssh_session session, auth_queue *pqueue);
 
-password_queue create_password_queue();
-char *wait_for_password(password_queue *queue);
-void push_password_msg(password_queue *queue, password_auth_attempt_msg *msg);
-password_auth_attempt_msg *get_password_msg(password_queue *queue);
-int is_password_queue_empty(password_queue *queue);
+auth_queue create_auth_queue();
+char *wait_for_creds(auth_queue *queue);
+void push_password_msg(auth_queue *queue, password_auth_attempt_msg *msg);
+password_auth_attempt_msg *get_password_msg(auth_queue *queue);
+int is_password_queue_empty(auth_queue *queue);
 
 #endif

--- a/honeyshell.h
+++ b/honeyshell.h
@@ -61,8 +61,5 @@ void handle_auth(ssh_session session, auth_queue *pqueue);
 
 auth_queue create_auth_queue();
 char *wait_for_creds(auth_queue *queue);
-void push_password_msg(auth_queue *queue, password_auth_attempt_msg *msg);
-password_auth_attempt_msg *get_password_msg(auth_queue *queue);
-int is_password_queue_empty(auth_queue *queue);
 
 #endif

--- a/queue.c
+++ b/queue.c
@@ -1,0 +1,90 @@
+#include <stdio.h>
+#include <poll.h>
+#include "./honeyshell.h"
+
+int wait_n_read(int fd, int *buf) {
+    struct pollfd pfd = {
+        .fd      = fd,
+        .events  = POLLIN,
+        .revents = 0
+    };
+
+    poll(&pfd, 1, -1);
+
+    int ret = read(fd, buf, sizeof(int));
+
+    if (ret == -1) {
+        perror("In read()");
+    }
+
+    return ret;
+}
+
+password_auth_attempt_msg *wait_for_password(password_queue *queue) {
+    int val = -1;
+
+    if (wait_n_read(queue->chan[0], &val) == -1) {
+        return NULL;
+    }
+
+    password_auth_attempt_msg *msg = get_password_msg(queue);
+    printf("%i\n", msg);
+    return msg;
+}
+
+password_queue create_password_queue() {
+    password_queue queue = {
+        .first = NULL,
+        .last = NULL,
+        .count = 0,
+        .chan = {0, 0}
+    };
+
+    return queue;
+}
+
+int is_password_queue_empty(password_queue *queue) {
+    return queue->count == 0; // queue->first == NULL && queue->last == NULL;
+}
+
+void push_password_msg(password_queue *queue, password_auth_attempt_msg *msg) {
+    if (queue == NULL) {
+        return;
+    }
+
+    password_queue_node new_node = {
+        .msg = msg
+    };
+
+    queue->count++;
+
+    if (queue->last == NULL || queue->count == 1) {
+        queue->last = &new_node;
+        queue->first = &new_node;
+        return;
+    }
+
+    queue->last->next_node = &new_node;
+    queue->last = &new_node;
+}
+
+password_auth_attempt_msg *get_password_msg(password_queue *queue) {
+printf("1\n");
+    if (queue->first == NULL || queue->count == 0) {
+printf("2\n");
+        return NULL;
+    }
+
+    queue->count--;
+
+printf("3\n");
+    password_auth_attempt_msg *msg = queue->first->msg;
+    queue->first = queue->first->next_node;
+
+printf("4 @%i\n", msg);
+    if (queue->first == NULL || queue->count == 0) {
+        queue->last = NULL;
+    }
+
+    return msg;
+}

--- a/queue.c
+++ b/queue.c
@@ -2,7 +2,7 @@
 #include <poll.h>
 #include "./honeyshell.h"
 
-int wait_n_read(int fd, char *buf) {
+void poll_queue(int fd) {
     struct pollfd pfd = {
         .fd      = fd,
         .events  = POLLIN,
@@ -10,20 +10,40 @@ int wait_n_read(int fd, char *buf) {
     };
 
     poll(&pfd, 1, -1);
+}
 
-    int ret = read(fd, buf, sizeof(char[512]) - 1);
+int wait_read_size(int fd, int *buf) {
+    poll_queue(fd);
+
+    int ret = read(fd, buf, sizeof(int));
 
     if (ret == -1) {
         perror("In read()");
     }
 
-    return ret;
+    return 1;
+}
+
+int wait_read_json(int fd, char *buf, int size) {
+    poll_queue(fd);
+
+    int ret = read(fd, buf, (sizeof(char) * size) + 1);
+
+    if (ret == -1) {
+        perror("In read()");
+    }
+
+    return 1;
 }
 
 char *wait_for_creds(auth_queue *queue) {
-    char *val = malloc(sizeof(char) * 512);
+    int size = 0;
 
-    if (wait_n_read(queue->chan[0], val) == -1) {
+    wait_read_size(queue->chan[0], &size);
+
+    char *val = malloc(sizeof(char) * size);
+
+    if (wait_read_json(queue->chan[0], val, size) == -1) {
         return NULL;
     }
 

--- a/queue.c
+++ b/queue.c
@@ -2,7 +2,7 @@
 #include <poll.h>
 #include "./honeyshell.h"
 
-int wait_n_read(int fd, int *buf) {
+int wait_n_read(int fd, char *buf) {
     struct pollfd pfd = {
         .fd      = fd,
         .events  = POLLIN,
@@ -11,7 +11,7 @@ int wait_n_read(int fd, int *buf) {
 
     poll(&pfd, 1, -1);
 
-    int ret = read(fd, buf, sizeof(int));
+    int ret = read(fd, buf, sizeof(char[256]) - 1);
 
     if (ret == -1) {
         perror("In read()");
@@ -21,15 +21,15 @@ int wait_n_read(int fd, int *buf) {
 }
 
 password_auth_attempt_msg *wait_for_password(password_queue *queue) {
-    int val = -1;
+    char *val = malloc(sizeof(char) * 256);
 
-    if (wait_n_read(queue->chan[0], &val) == -1) {
+    if (wait_n_read(queue->chan[0], val) == -1) {
         return NULL;
     }
 
-    password_auth_attempt_msg *msg = get_password_msg(queue);
-    printf("%i\n", msg);
-    return msg;
+    printf("-> %s\n", val);
+
+    return NULL;
 }
 
 password_queue create_password_queue() {
@@ -69,19 +69,15 @@ void push_password_msg(password_queue *queue, password_auth_attempt_msg *msg) {
 }
 
 password_auth_attempt_msg *get_password_msg(password_queue *queue) {
-printf("1\n");
     if (queue->first == NULL || queue->count == 0) {
-printf("2\n");
         return NULL;
     }
 
     queue->count--;
 
-printf("3\n");
     password_auth_attempt_msg *msg = queue->first->msg;
     queue->first = queue->first->next_node;
 
-printf("4 @%i\n", msg);
     if (queue->first == NULL || queue->count == 0) {
         queue->last = NULL;
     }

--- a/queue.c
+++ b/queue.c
@@ -20,16 +20,14 @@ int wait_n_read(int fd, char *buf) {
     return ret;
 }
 
-password_auth_attempt_msg *wait_for_password(password_queue *queue) {
+char *wait_for_password(password_queue *queue) {
     char *val = malloc(sizeof(char) * 256);
 
     if (wait_n_read(queue->chan[0], val) == -1) {
         return NULL;
     }
 
-    printf("-> %s\n", val);
-
-    return NULL;
+    return val;
 }
 
 password_queue create_password_queue() {

--- a/queue.c
+++ b/queue.c
@@ -11,7 +11,7 @@ int wait_n_read(int fd, char *buf) {
 
     poll(&pfd, 1, -1);
 
-    int ret = read(fd, buf, sizeof(char[256]) - 1);
+    int ret = read(fd, buf, sizeof(char[512]) - 1);
 
     if (ret == -1) {
         perror("In read()");
@@ -20,8 +20,8 @@ int wait_n_read(int fd, char *buf) {
     return ret;
 }
 
-char *wait_for_password(password_queue *queue) {
-    char *val = malloc(sizeof(char) * 256);
+char *wait_for_creds(auth_queue *queue) {
+    char *val = malloc(sizeof(char) * 512);
 
     if (wait_n_read(queue->chan[0], val) == -1) {
         return NULL;
@@ -30,55 +30,10 @@ char *wait_for_password(password_queue *queue) {
     return val;
 }
 
-password_queue create_password_queue() {
-    password_queue queue = {
-        .first = NULL,
-        .last = NULL,
-        .count = 0,
+auth_queue create_auth_queue() {
+    auth_queue queue = {
         .chan = {0, 0}
     };
 
     return queue;
-}
-
-int is_password_queue_empty(password_queue *queue) {
-    return queue->count == 0; // queue->first == NULL && queue->last == NULL;
-}
-
-void push_password_msg(password_queue *queue, password_auth_attempt_msg *msg) {
-    if (queue == NULL) {
-        return;
-    }
-
-    password_queue_node new_node = {
-        .msg = msg
-    };
-
-    queue->count++;
-
-    if (queue->last == NULL || queue->count == 1) {
-        queue->last = &new_node;
-        queue->first = &new_node;
-        return;
-    }
-
-    queue->last->next_node = &new_node;
-    queue->last = &new_node;
-}
-
-password_auth_attempt_msg *get_password_msg(password_queue *queue) {
-    if (queue->first == NULL || queue->count == 0) {
-        return NULL;
-    }
-
-    queue->count--;
-
-    password_auth_attempt_msg *msg = queue->first->msg;
-    queue->first = queue->first->next_node;
-
-    if (queue->first == NULL || queue->count == 0) {
-        queue->last = NULL;
-    }
-
-    return msg;
 }

--- a/ssh_server.go
+++ b/ssh_server.go
@@ -97,21 +97,19 @@ func (server *SSHServer) HandleSSHAuth(session *C.ssh_session) bool {
 
 	go func() {
 		for {
-			if C.is_password_queue_empty(&password_queue) == 1 {
-				continue
-			}
+			// if C.is_password_queue_empty(&password_queue) == 1 {
+			// 	continue
+			// }
 
-			if msg := C.get_password_msg(&password_queue); msg != nil {
+			// if msg := C.get_password_msg(&password_queue); msg != nil {
+			// 	fmt.Println("Get message") //fmt.Println("->", msg)
+			// }
+
+			msg := C.wait_for_password(&password_queue)
+
+			if msg != nil {
 				fmt.Println("->", msg)
 			}
-
-			// fmt.Println("Here")
-			// msg := C.wait_for_password(&password_queue)
-			// fmt.Println("Here", msg)
-
-			// if msg != nil {
-			// 	fmt.Println("->", msg)
-			// }
 		}
 	}()
 

--- a/ssh_server.go
+++ b/ssh_server.go
@@ -110,6 +110,10 @@ func (server *SSHServer) HandleSSHAuth(session *C.ssh_session) bool {
 
 				logman.Printf("%s %s pass:%s\n", ip.String(), parts[0], parts[1])
 				log.Printf("%s %s pass:%s\n", ip.String(), parts[0], parts[1])
+
+				if parts[2] == "3" {
+					break
+				}
 				// } else {
 				// 	fmt.Println("I don't know what happened")
 			}


### PR DESCRIPTION
This is a working branch that will upgrade the version of libssh to the latest, which deprecates the currently used auth methods.

The branch still needs to be fully tested and cleaned up. I also need to figure out how to escape strings.